### PR TITLE
Fix action compatibility with npm

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const makeNpmrc = (registry, scope, token) => `
 @${scope}:registry=${registry}
 always-auth=true
 ${registry}:_auth=${token}
-${registry}:_authToken=${token}
+//${registry}:_authToken=${token}
 `;
 
 try {


### PR DESCRIPTION
When this GitHub Action is used to `yarn install` dependencies, all works as expected. When the same is performed with `npm install`, 401 is returned for packages that come from Nexus, internal package registry.

Adding leading slashes will fix this issue by making sure that the appropriate syntax is used to make access to Nexus npm compatible.

The fix follows the example from the docs: https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow#create-and-check-in-a-project-specific-npmrc-file